### PR TITLE
Initial CI build for libs and headers

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,76 @@
+name: Build and Release
+
+on:
+  push:
+    tags:        
+      - '*'
+
+jobs:
+
+  release:
+
+    strategy:
+      matrix:
+        # Build on not-the-latest to keep dependency versions modest.
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      - name: Set up a build environment.
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential cmake
+          sudo apt install -y zlib1g-dev liblz4-dev
+
+      - name: Install TCL 9 to the build environment.
+        run: |
+          git clone --depth=1 --branch core-9-0-1-rc https://github.com/tcltk/tcl.git
+          cd tcl/unix/
+          ./configure
+          make
+          sudo make install
+
+      - name: Install Jansson to the build environment.
+        run: |
+          git clone https://github.com/akheron/jansson.git
+          cd jansson/
+          git checkout v2.14
+          cmake -B build
+          cmake --build build
+          sudo cmake --install build
+
+      - name: Install Libharu to the build environment (static and dynamic libs both).
+        run: |
+          git clone https://github.com/libharu/libharu.git
+          cd libharu
+          git checkout v2.4.4
+          cmake -DBUILD_SHARED_LIBS=OFF -B build
+          cmake --build build
+          sudo cmake --install build
+          cmake -DBUILD_SHARED_LIBS=ON -B build
+          cmake --build build
+          sudo cmake --install build
+
+      - name: Check out our dlsh code for the current tag.
+        uses: actions/checkout@v4
+
+      - name: Install dlsh into an artifacts dir.
+        run: |
+          cmake -DCMAKE_INSTALL_PREFIX=/work/artifacts/ -B build
+          cmake --build build
+          sudo cmake --install build
+
+      - name: Create a platform-specific zip of libs and headers.
+        run: |
+          cd /work/artifacts
+          sudo zip -r dlsh-${{ runner.os }}-$(dpkg --print-architecture)-${{ github.ref_name }}.zip .
+
+      - name: Create a GitHub release for the current tag and artifacts.
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: /work/artifacts/*.zip
+          body: libs and headers for dlsh version ${{ github.ref_name }}
+          generateReleaseNotes: true
+          allowUpdates: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ include_directories(${TCL_INCLUDE_DIR} src)
 # dlsh
 ###############################
 add_library(dlsh SHARED src/dfana.c src/tcl_dlg.c src/dfevt.c src/dlsh_pkg.c src/tcl_df.c src/tcl_dm.c src/dlarith.c src/dmana.c src/tcl_dl.c src/dgjson.c src/lablib/gbufutl.c src/lablib/gbuf.c src/lablib/cg_ps.c src/lablib/cg_base.c src/lablib/axes.c src/lablib/cgraph.c src/lablib/timer.c src/lablib/utilc_unix.c src/lablib/randvars.c src/lablib/prmutil.c src/lablib/dfutils.c src/lablib/df.c src/lablib/dynio.c src/lablib/rawapi.c src/lablib/lodepng.c src/lablib/lz4utils.c src/lablib/dslog.c )
+set_target_properties(dlsh PROPERTIES PUBLIC_HEADER "src/dfana.h;src/lablib/df.h;src/lablib/dynio.h;src/tcl_dl.h;src/lablib/cgraph.h;src/lablib/gbuf.h;")
 
 project(dlsh-static)
 
@@ -80,14 +81,6 @@ target_link_libraries( dlsh ${LIBJANSSON} ${TCLLIB} ${PDFLIB} ${LZ4LIB} ${ZLIB} 
 
 target_link_libraries( dlsh-static ${LIBJANSSON} ${TCLLIB} ${PDFLIB} ${LZ4LIB} ${ZLIB} )
 
-set (CMAKE_INSTALL_PREFIX ../dlshell/dlshell.vfs/lib/dlsh)
-if (WIN32)
-INSTALL(TARGETS dlsh
-        LIBRARY DESTINATION "Windows NT/amd64"
-)
-elseif(APPLE)
-else ()
-INSTALL(TARGETS dlsh
-        LIBRARY DESTINATION "Linux/aarch64"
-)
-endif()
+INSTALL(TARGETS dlsh PUBLIC_HEADER)
+INSTALL(TARGETS dlsh LIBRARY)
+INSTALL(TARGETS dlsh-static LIBRARY)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# dlsh
+
+This repo uses GitHub Actions to build dlsh whenever we push a new repo tag.
+The workflow might go like this:
+
+ - Make changes locally.
+ - Commit and push changes to this repo.
+ - Create a new tag locally.
+   - The tag name should be a version number, like `0.0.1`.
+   - `git tag --list`
+   - Pick a new version number / tag name that doesn't exist yet.
+   - Annotated tags with `-a` can have metadata, including messages, which is nice.
+   - `git tag -a 0.0.2 -m "Now with lasers."`
+   - `git push --tags`
+ - When the new tag is pused to GitHub, GitHub Actions will kick off a new build and release.
+ - See workflow definition(s) like [build-and-release.yml](./.github/workflows/build-and-release.yml).
+ - Follow workflow progress at the repo [Actions tab](https://github.com/benjamin-heasly/dlsh/actions).
+ - See completed releases and build artifacts at the repo [Releases](https://github.com/benjamin-heasly/dlsh/releases).

--- a/scripts/docker/Dockerfile-build
+++ b/scripts/docker/Dockerfile-build
@@ -1,0 +1,63 @@
+# This Dockerfile was helpful for building and packaging dlsh.
+# Docker gives a clean environment, meaning the steps below must account for all dependencies.
+# Docker also gives us a local environment that's easy to iterate on.
+# Getting this working was the basis for the automated CI builds, over in .github/workflows/.
+#
+# To run this docker build cd to the dlsh repo root and:
+#
+#   docker build . -f scripts/docker/Dockerfile-build -t dlsh-build:local
+#
+# To sanity check the libs and headers that are ready for packaging:
+#
+#   docker run --rm -ti dlsh-build:local ls -alth /work/package/lib
+#   docker run --rm -ti dlsh-build:local ls -alth /work/package/include
+
+
+# Start with a fresh Ubuntu environment.
+FROM ubuntu:22.04
+
+# Set up a dev tools and dlsh build dependencies.
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && apt update \
+    && apt install --no-install-recommends --yes git wget ca-certificates build-essential cmake zlib1g-dev liblz4-dev \
+    && apt-get clean \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install TCL 9 to the build environment.
+WORKDIR /work
+RUN git clone --depth=1 --branch core-9-0-1-rc https://github.com/tcltk/tcl.git \
+  && cd tcl/unix/ \
+  && ./configure \
+  && make \
+  && make install
+
+# Install the Jansson JSON dependency.
+WORKDIR /work
+RUN git clone https://github.com/akheron/jansson.git \
+  && cd jansson/ \
+  && git checkout v2.14 \
+  && mkdir build \
+  && cd build/ \
+  && cmake .. \
+  && make \
+  && make install
+
+# Install the libharu PDF dependency -- both static and dynamic builds.
+WORKDIR /work
+RUN git clone https://github.com/libharu/libharu.git \
+  && cd libharu \
+  && git checkout v2.4.4 \
+  && cmake -DBUILD_SHARED_LIBS=OFF -B build \
+  && cmake --build build \
+  && cmake --install build \
+  && cmake -DBUILD_SHARED_LIBS=ON -B build \
+  && cmake --build build \
+  && cmake --install build
+
+# Build dlsh itself and install to a packaging dir.
+ADD . /work/dlsh/
+WORKDIR /work/dlsh/
+RUN cmake -DCMAKE_INSTALL_PREFIX=/work/package/ -B build \
+  && cmake --build build \
+  && cmake --install build


### PR DESCRIPTION
Hi @sheinb -- here's a start at building and releasing dlsh via CI.

I started with building dlsh in a Dockerfile.  This was a handy way to work locally, and still have the environment be clean and repeatable every time.  Once this worked, I translated the build steps to a GitHub Actions YAML file.  I included the Dockerfile since this felt useful, but the GitHub YAML is probably the real source of truth.

The build is triggered when we push a repo tag, and it uses the tag name as the release version, say `0.0.1` etc.  So far, the build is running on Ubuntu amd64 and arm64.  It's producing a zip file (one for each arch) with libs and headers, downloadable from the GitHub repo [Releases](https://github.com/benjamin-heasly/dlsh/releases).

I'm using the versioned zip artifact over in the dserv build, and this seems to be working!  This is encouraging but I'm also wondering about other ways we might set this up --
 - To support builds like dserv, with libs and headers, maybe we want to produce a .deb (or other) package instead of an ad-hoc .zip.
 - Maybe we want to add another CI workflow  to create the big `dlsh.zip` with TCL libs and other dependencies.
 - Maybe CPack is a better way to create packages.