### PR TITLE
Add Tktable 2.12.1 to CI builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,10 @@ env:
   # TEA package versions - update these when upgrading
   TCL_VERSION: "9.0.1"
   TCL_TAG: "core-9-0-1"
+  TK_TAG: "core-9-0-1"
   TDOM_VERSION: "0.9.6"
+  TKTABLE_VERSION: "2.12.1"
+  TKTABLE_TAG: "tktable-2-12-1"
 
 jobs:
   #############################################
@@ -24,6 +27,7 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential cmake zip
           sudo apt install -y libpq-dev
+          sudo apt install -y libx11-dev libxft-dev libxss-dev libxext-dev
 
       - name: Check out code
         uses: actions/checkout@v4
@@ -47,12 +51,40 @@ jobs:
           make -j$(nproc)
           make install
 
+      - name: Cache Tk build
+        id: cache-tk
+        uses: actions/cache@v4
+        with:
+          path: tk-install
+          key: tk-${{ env.TCL_VERSION }}-linux-x86_64
+
+      - name: Build Tk
+        if: steps.cache-tk.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o tk-src.tar.gz https://github.com/tcltk/tk/archive/refs/tags/${{ env.TK_TAG }}.tar.gz
+          tar xzf tk-src.tar.gz
+          cd tk-${{ env.TK_TAG }}/unix
+          ./configure --prefix=${{ github.workspace }}/tk-install \
+            --with-tcl=${{ github.workspace }}/tcl-install/lib
+          make -j$(nproc)
+          make install
+
       - name: Build tdom
         run: |
           curl -L -o tdom-src.tgz http://tdom.org/downloads/tdom-${{ env.TDOM_VERSION }}-src.tgz
           tar xzf tdom-src.tgz
           cd tdom-*/
           ./configure --with-tcl=${{ github.workspace }}/tcl-install/lib
+          make -j$(nproc)
+
+      - name: Build Tktable
+        run: |
+          curl -L -o tktable-src.tar.gz https://github.com/bohagan1/TkTable/releases/download/${{ env.TKTABLE_TAG }}/tktable-${{ env.TKTABLE_VERSION }}-src.tar.gz
+          tar xzf tktable-src.tar.gz
+          cd tktable-*/
+          ./configure \
+            --with-tcl=${{ github.workspace }}/tcl-install/lib \
+            --with-tk=${{ github.workspace }}/tk-install/lib
           make -j$(nproc)
 
       - name: Build (CMake packages)
@@ -69,6 +101,11 @@ jobs:
           mkdir -p install/lib/tdom/Linux/x86_64
           cp tdom-*/*.so install/lib/tdom/Linux/x86_64/
 
+          # Tktable
+          mkdir -p install/lib/Tktable/Linux/x86_64
+          cp tktable-*/*.so install/lib/Tktable/Linux/x86_64/
+          cp tktable-*/library/tkTable.tcl install/lib/Tktable/
+
       - name: Upload platform artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -84,6 +121,7 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential cmake zip
           sudo apt install -y libpq-dev
+          sudo apt install -y libx11-dev libxft-dev libxss-dev libxext-dev
 
       - name: Check out code
         uses: actions/checkout@v4
@@ -115,12 +153,40 @@ jobs:
           make -j$(nproc)
           make install
 
+      - name: Cache Tk build
+        id: cache-tk
+        uses: actions/cache@v4
+        with:
+          path: tk-install
+          key: tk-${{ env.TCL_VERSION }}-linux-aarch64
+
+      - name: Build Tk
+        if: steps.cache-tk.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o tk-src.tar.gz https://github.com/tcltk/tk/archive/refs/tags/${{ env.TK_TAG }}.tar.gz
+          tar xzf tk-src.tar.gz
+          cd tk-${{ env.TK_TAG }}/unix
+          ./configure --prefix=${{ github.workspace }}/tk-install \
+            --with-tcl=${{ github.workspace }}/tcl-install/lib
+          make -j$(nproc)
+          make install
+
       - name: Build tdom
         run: |
           curl -L -o tdom-src.tgz http://tdom.org/downloads/tdom-${{ env.TDOM_VERSION }}-src.tgz
           tar xzf tdom-src.tgz
           cd tdom-*/
           ./configure --with-tcl=${{ github.workspace }}/tcl-install/lib
+          make -j$(nproc)
+
+      - name: Build Tktable
+        run: |
+          curl -L -o tktable-src.tar.gz https://github.com/bohagan1/TkTable/releases/download/${{ env.TKTABLE_TAG }}/tktable-${{ env.TKTABLE_VERSION }}-src.tar.gz
+          tar xzf tktable-src.tar.gz
+          cd tktable-*/
+          ./configure \
+            --with-tcl=${{ github.workspace }}/tcl-install/lib \
+            --with-tk=${{ github.workspace }}/tk-install/lib
           make -j$(nproc)
 
       - name: Build (CMake packages)
@@ -136,6 +202,11 @@ jobs:
           # tdom
           mkdir -p install/lib/tdom/Linux/aarch64
           cp tdom-*/*.so install/lib/tdom/Linux/aarch64/
+
+          # Tktable
+          mkdir -p install/lib/Tktable/Linux/aarch64
+          cp tktable-*/*.so install/lib/Tktable/Linux/aarch64/
+          cp tktable-*/library/tkTable.tcl install/lib/Tktable/
 
       - name: Upload platform artifacts
         uses: actions/upload-artifact@v4
@@ -182,12 +253,40 @@ jobs:
           make -j$(sysctl -n hw.ncpu)
           make install
 
+      - name: Cache Tk build
+        id: cache-tk
+        uses: actions/cache@v4
+        with:
+          path: tk-install
+          key: tk-${{ env.TCL_VERSION }}-macos-arm64
+
+      - name: Build Tk
+        if: steps.cache-tk.outputs.cache-hit != 'true'
+        run: |
+          curl -L -o tk-src.tar.gz https://github.com/tcltk/tk/archive/refs/tags/${{ env.TK_TAG }}.tar.gz
+          tar xzf tk-src.tar.gz
+          cd tk-${{ env.TK_TAG }}/unix
+          ./configure --prefix=${{ github.workspace }}/tk-install \
+            --with-tcl=${{ github.workspace }}/tcl-install/lib
+          make -j$(sysctl -n hw.ncpu)
+          make install
+
       - name: Build tdom
         run: |
           curl -L -o tdom-src.tgz http://tdom.org/downloads/tdom-${{ env.TDOM_VERSION }}-src.tgz
           tar xzf tdom-src.tgz
           cd tdom-*/
           ./configure --with-tcl=${{ github.workspace }}/tcl-install/lib
+          make -j$(sysctl -n hw.ncpu)
+
+      - name: Build Tktable
+        run: |
+          curl -L -o tktable-src.tar.gz https://github.com/bohagan1/TkTable/releases/download/${{ env.TKTABLE_TAG }}/tktable-${{ env.TKTABLE_VERSION }}-src.tar.gz
+          tar xzf tktable-src.tar.gz
+          cd tktable-*/
+          ./configure \
+            --with-tcl=${{ github.workspace }}/tcl-install/lib \
+            --with-tk=${{ github.workspace }}/tk-install/lib
           make -j$(sysctl -n hw.ncpu)
 
       - name: Set up keychain for code signing
@@ -232,6 +331,11 @@ jobs:
           # tdom
           mkdir -p install/lib/tdom/Darwin/arm64
           cp tdom-*/*.dylib install/lib/tdom/Darwin/arm64/
+
+          # Tktable
+          mkdir -p install/lib/Tktable/Darwin/arm64
+          cp tktable-*/*.dylib install/lib/Tktable/Darwin/arm64/
+          cp tktable-*/library/tkTable.tcl install/lib/Tktable/
 
       - name: Upload platform artifacts
         uses: actions/upload-artifact@v4

--- a/README-TEA-packages.md
+++ b/README-TEA-packages.md
@@ -171,9 +171,11 @@ Common TEA package download locations:
 - **thread**: `https://core.tcl-lang.org/thread/tarball/thread-<version>.tar.gz?uuid=thread-<tag>`
 - **sqlite**: `https://sqlite.org/<year>/sqlite-autoconf-<version>.tar.gz`
 - **tcllib**: `https://core.tcl-lang.org/tcllib/tarball/tcllib-<version>.tar.gz?uuid=tcllib-<tag>`
+- **Tktable**: `https://github.com/bohagan1/TkTable/releases/download/tktable-<tag>/tktable-<version>-src.tar.gz` (requires Tk build for `--with-tk=`)
 
 ## Notes
 
 - Pure Tcl packages (no binaries) can simply be dropped in `vfs/lib/` without platform subdirectories
-- The Tcl build is cached per-platform to speed up subsequent runs
+- The Tcl and Tk builds are cached per-platform to speed up subsequent runs
+- Tk is built only as a build dependency (for Tk extensions like Tktable) and is NOT included in the VFS
 - Binaries are NOT committed to the repo - CI builds them fresh each release

--- a/vfs/lib/Tktable/pkgIndex.tcl
+++ b/vfs/lib/Tktable/pkgIndex.tcl
@@ -1,0 +1,14 @@
+#
+# Tcl package index file for Tktable
+# NOTE: Version must match TKTABLE_VERSION in .github/workflows/release.yml
+#
+
+package ifneeded Tktable 2.12.1 [list apply {{dir} {
+    load [file join $dir $::tcl_platform(os) $::tcl_platform(machine) \
+	libtcl9Tktable2.12.1[info sharedlibextension]] Tktable
+
+    set initScript [file join $dir tkTable.tcl]
+    if {[file exists $initScript]} {
+	source -encoding utf-8 $initScript
+    }
+}} $dir]


### PR DESCRIPTION
## Summary
- Build Tk 9.0.1 as a cached build dependency (not shipped in VFS) across all three platforms
- Add Tktable 2.12.1 (from [bohagan1/TkTable](https://github.com/bohagan1/TkTable)) as a TEA package built in CI
- Add X11 dev dependencies on Linux for Tk builds
- Create `vfs/lib/Tktable/pkgIndex.tcl` with platform-aware loading and `tkTable.tcl` init script sourcing

## Test plan
- [ ] CI builds succeed on all three platforms (Linux x86_64, Linux aarch64, macOS arm64)
- [ ] Verify Tktable .so/.dylib appears in build artifacts
- [ ] Verify library filename matches pkgIndex.tcl expectation (`libtcl9Tktable2.12.1`)
- [ ] Test `package require Tktable` loads correctly from VFS

🤖 Generated with [Claude Code](https://claude.com/claude-code)