### PR TITLE
Fix macOS Tk build: use --enable-aqua

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,7 +267,8 @@ jobs:
           tar xzf tk-src.tar.gz
           cd tk-${{ env.TK_TAG }}/unix
           ./configure --prefix=${{ github.workspace }}/tk-install \
-            --with-tcl=${{ github.workspace }}/tcl-install/lib
+            --with-tcl=${{ github.workspace }}/tcl-install/lib \
+            --enable-aqua
           make -j$(sysctl -n hw.ncpu)
           make install
 


### PR DESCRIPTION
## Summary
- Add `--enable-aqua` to the macOS Tk configure step so it uses Cocoa instead of X11
- Fixes `'X11/Xlib.h' file not found` build failure on macOS runners

## Context
Both Linux builds passed on the previous run. macOS failed because Tk defaults to X11 on `./configure` and the macOS runners don't have X11/XQuartz headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)